### PR TITLE
Don't use bucky bits to input control characters.

### DIFF
--- a/supdup.c
+++ b/supdup.c
@@ -823,27 +823,9 @@ supdup (char *loc)
               high_bits = 2;
               c &= 0177;
             }
-          if ((c & 0140) == 0)
-            {
-              switch (c)
-                {
-                case 010:
-                case 011:
-                case 012:
-                case 013:
-                case 014:
-                case 015:
-                case 032:
-                case 033:
-                case 037:
-                  break;
-                default:
-                  high_bits |= 1;
-                  c = c + '@';
-                  break;
-                }
-            }
-          if (high_bits)
+          if (c == ITP_ESCAPE)
+            *netfrontp++ = ITP_ESCAPE;
+          else if (high_bits)
             {
               *netfrontp++ = ITP_ESCAPE;
               *netfrontp++ = high_bits + 0100;


### PR DESCRIPTION
The supdup client uses the "intelligent terminal protocol" to transfer input control characters as their corresponding upper case character with the control bit set.

I'd argue that this is confusing for applications, unless %TOCFI also is set.

RFC 734 doesn't clearly say what to do.  There's this:

> Input differs dramatically  between the 7-bit  and 12-bit character  sets. In the 7-bit character set, all characters input whose value is 037  octal or less  are assumed  to be  (ASCII) control  characters.  In  the  12-bit character set,  there are  5 "bucky"  bits which  may be  attached to  the character.
> ...
> Under normal circumstances, characters input from the keyboard are sent to the foreign host as is.  There  are two exceptions; the first occurs  when an octal 034  character is to  be sent; it  must be quoted  by being  sent twice, because 034 is used as  an escape character for protocol  commands.  The second  exception occurs  when  %TOFCI is  set  and a  character with non-zero bucky bits is to be sent.

But also this:

```
In addition, the following special characters exist for input only.  These
characters are  function keys  rather than  printing characters;  however,
some of these  characters have some  format effect or  graphic which  they
echo as; the host, not the SUPDUP program, handles any such mappings.

Value   Character       Usual echo              Usual Function

 0000   [NULL]
 0010   [BACK SPACE]                            text formatting
 0011   [TAB]                                   text formatting
 0012   [LINE FEED]                             text formatting
 0013   [VT]                                    text formatting
 0014   [FORM]                                  text formatting
 0015   [RETURN]                                text formatting
 0032   [CALL]          uparrow-Z               escape to system
 0033   [ALTMODE]       lozenge or $            special activation
 0037   [BACK NEXT]     uparrow-underscore      monitor command prefix
 0177   [RUBOUT]                                character delete
  
 4101   [ESCAPE]                                local terminal command
 4102   [BREAK]                                 local subsystem escape
 4103   [CLEAR]
 4110   [HELP]                                  requests a help message

BUCKY BITS

For all input characters, the following  "bucky bits" may be added to  the
character.