### PR TITLE
Support for using Chaosnet streams (provided by cbridge).

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,19 @@
 
 PREFIX ?= /usr/local
 
+OS_NAME = $(shell uname)
+ifeq ($(OS_NAME), Darwin)
+OS = OSX
+endif
+
+
 CFLAGS = -g -Wall
-LDFLAGS = -g
+# Mac OSX
+ifeq ($(OS), OSX)
+LDFLAGS = -L/opt/local/lib
+endif
 OBJS = supdup.o charmap.o
-LIBS = -lncurses
+LIBS = -lncurses -lresolv
 CLIENT = supdup
 SERVER = supdupd
 CC = cc
@@ -14,7 +23,7 @@ CC = cc
 all:	$(CLIENT)
 
 $(CLIENT): $(OBJS)
-	$(CC) $(LDFLAGS) -o $@ $^ $(LIBS)
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $^ $(LIBS)
 
 $(SERVER): supdupd.o
 	$(CC) $(LDFLAGS) -o $@ $^

--- a/supdup.c
+++ b/supdup.c
@@ -421,7 +421,8 @@ main (int argc, char **argv)
   if (sp == 0)
     {
       fprintf (stderr, "supdup: tcp/supdup: unknown service.\n");
-      sp->s_port = 95; // standard
+      sp = (struct servent *)malloc(sizeof(struct servent));
+      sp->s_port = htons(95); // standard
     }
 
 #if !USE_TERMIOS
@@ -630,7 +631,7 @@ main (int argc, char **argv)
   }
   } else {
 #endif
-  printf("Trying %s ...", inet_ntoa (tsin.sin_addr));
+    printf("Trying %s port %d ...", inet_ntoa (tsin.sin_addr), ntohs(tsin.sin_port));
   fflush (stdout);
   if (connect (net, (struct sockaddr *) &tsin, sizeof (tsin)) < 0)
 /* >> Should try other addresses here (like BSD telnet) #ifdef h_addr */

--- a/supdup.c
+++ b/supdup.c
@@ -661,7 +661,15 @@ main (int argc, char **argv)
     supdup (myloc);
   ttyoflush ();
   mode (0);
+  // cosmetics
+  if (clr_eol)
+    tputs (clr_eol, columns, putch);
+  ttyoflush ();
   fprintf (stderr, "Connection closed by %s.\n", hostname);
+  // cosmetics
+  if (clr_eol)
+    tputs (clr_eol, columns, putch);
+  ttyoflush ();
   exit (0);
 }
 
@@ -1404,7 +1412,14 @@ punt (int logout_p)
   if (connected)
     {
       shutdown (net, 2);
+      // cosmetics
+      if (clr_eol)
+	tputs (clr_eol, columns, putch);
+      ttyoflush ();
       printf ("Connection closed.\n");
+      // cosmetics
+      if (clr_eol)
+	tputs (clr_eol, columns, putch);
       ttyoflush ();
       close (net);
     }

--- a/supdup.c
+++ b/supdup.c
@@ -1396,6 +1396,9 @@ suprcv (void)
   int c;
   static int state = SR_DATA;
   static int y;
+  // The text until the first TDNOP should be shown in ASCII, without translation.
+  // See RFC 734, bottom of page 3, or SUPIN2 in SYSNET;SUPDUP > (for ITS).
+  static int greeting_done = 0;
 
   while (scc > 0)
     {
@@ -1411,7 +1414,7 @@ suprcv (void)
               if (currcol < columns)
                 {
                   currcol++;
-                  if(unicode_translation) {
+                  if(unicode_translation && greeting_done) {
                     char *s = charmap[c].utf8;
                     while(*s) {
                       *ttyfrontp++ = *s++;
@@ -1485,6 +1488,7 @@ suprcv (void)
                 tputs (clr_eol, columns - currcol, putch);
               continue;
             case TDNOP:
+	      greeting_done = 1;
               continue;
             case TDORS:         /* ignore interrupts and */
 	      if (debug) fprintf(stderr,"TDORS at %d %d\n", currline, currcol);

--- a/supdup.c
+++ b/supdup.c
@@ -421,7 +421,7 @@ main (int argc, char **argv)
   if (sp == 0)
     {
       fprintf (stderr, "supdup: tcp/supdup: unknown service.\n");
-      sp->s_port = 79; // standard
+      sp->s_port = 95; // standard
     }
 
 #if !USE_TERMIOS


### PR DESCRIPTION
If the host parameter given can be on Chaosnet (based on DNS or that it's a valid 16-bit chaos address), connect using the stream interface of cbridge, else use Internet as usual.

Also send three extra Supdup variables (supported by ITS), and some minor things.