### PR TITLE
 Support for using Chaosnet streams (provided by cbridge).

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Makefile for the supdup server and user.
+# Makefile for the supdup server and client.
 
 PREFIX ?= /usr/local
 
@@ -7,30 +7,30 @@ ifeq ($(OS_NAME), Darwin)
 OS = OSX
 endif
 
-
+CC = cc
 CFLAGS = -g -Wall
+LDFLAGS = -g
+
 # Mac OSX
 ifeq ($(OS), OSX)
 LDFLAGS = -L/opt/local/lib
 endif
-OBJS = supdup.o charmap.o
-LIBS = -lncurses -lresolv
-CLIENT = supdup
-SERVER = supdupd
-CC = cc
 
 # The server isn't ready for prime time.
-all:	$(CLIENT)
+all:	supdup
 
-$(CLIENT): $(OBJS)
-	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $^ $(LIBS)
+SUPDUP_OBJS = supdup.o charmap.o
+supdup: $(SUPDUP_OBJS)
+	$(CC) $(LDFLAGS) -o $@ $(SUPDUP_OBJS) -lncurses -lresolv
 
-$(SERVER): supdupd.o
-	$(CC) $(LDFLAGS) -o $@ $^
+SUPDUPD_OBJS = supdupd.o
+supdupd: $(SUPDUPD_OBJS)
+	$(CC) $(LDFLAGS) -o $@ $(SUPDUPD_OBJS)
 
-install: $(CLIENT) $(SERVER)
-	install -m 0755 supdup ${PREFIX}/bin
-	test -x supdupd && install -m 0755 supdupd ${PREFIX}/bin
+install: supdup
+	install -m 0755 supdup $(PREFIX)/bin
+	test -x supdupd && install -m 0755 supdupd $(PREFIX)/bin
 
 clean:
-	rm -f $(CLIENT) $(SERVER) $(OBJS)
+	rm -f *.o
+	rm -f supdup supdupd

--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,19 @@
 
 PREFIX ?= /usr/local
 
+OS_NAME = $(shell uname)
+ifeq ($(OS_NAME), Darwin)
+OS = OSX
+endif
+
+
 CFLAGS = -g -Wall
-LDFLAGS = -g
+# Mac OSX
+ifeq ($(OS), OSX)
+LDFLAGS = -L/opt/local/lib
+endif
 OBJS = supdup.o charmap.o
-LIBS = -lncurses
+LIBS = -lncurses -lresolv
 CLIENT = supdup
 SERVER = supdupd
 CC = cc
@@ -14,7 +23,7 @@ CC = cc
 all:	$(CLIENT)
 
 $(CLIENT): $(OBJS)
-	$(CC) $(LDFLAGS) -o $@ $^ $(LIBS)
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $^ $(LIBS)
 
 $(SERVER): supdupd.o
 	$(CC) $(LDFLAGS) -o $@ $^

--- a/supdup.c
+++ b/supdup.c
@@ -447,13 +447,16 @@ int
 to_bps(int speed)
 {
   switch (speed) {
+    // Cf. BAUDRT in SYSTEM;TS3TTY >
+    //case B75: return 75;
+    //case B134: return 134;
+    //case B200: return 200;
+    //case B19200: return 19200;
+    //case B38400: return 38400;
   case B0: return 0;
   case B50: return 50;
-  case B75: return 75;
   case B110: return 110;
-  case B134: return 134;
   case B150: return 150;
-  case B200: return 200;
   case B300: return 300;
   case B600: return 600;
   case B1200: return 1200;
@@ -461,9 +464,8 @@ to_bps(int speed)
   case B2400: return 2400;
   case B4800: return 4800;
   case B9600: return 9600;
-  case B19200: return 19200;
-  case B38400: return 38400;
-  default: return 0;
+    // reasonable default?
+  default: return 9600;
   }
 }
 

--- a/supdup.c
+++ b/supdup.c
@@ -421,7 +421,8 @@ main (int argc, char **argv)
   if (sp == 0)
     {
       fprintf (stderr, "supdup: tcp/supdup: unknown service.\n");
-      sp->s_port = 95; // standard
+      sp = (struct servent *)malloc(sizeof(struct servent));
+      sp->s_port = htons(95); // standard
     }
 
 #if !USE_TERMIOS
@@ -630,7 +631,7 @@ main (int argc, char **argv)
   }
   } else {
 #endif
-  printf("Trying %s ...", inet_ntoa (tsin.sin_addr));
+    printf("Trying %s port %d ...", inet_ntoa (tsin.sin_addr), ntohs(tsin.sin_port));
   fflush (stdout);
   if (connect (net, (struct sockaddr *) &tsin, sizeof (tsin)) < 0)
 /* >> Should try other addresses here (like BSD telnet) #ifdef h_addr */

--- a/supdup.c
+++ b/supdup.c
@@ -661,7 +661,15 @@ main (int argc, char **argv)
     supdup (myloc);
   ttyoflush ();
   mode (0);
+  // cosmetics
+  if (clr_eol)
+    tputs (clr_eol, columns, putch);
+  ttyoflush ();
   fprintf (stderr, "Connection closed by %s.\n", hostname);
+  // cosmetics
+  if (clr_eol)
+    tputs (clr_eol, columns, putch);
+  ttyoflush ();
   exit (0);
 }
 
@@ -1404,7 +1412,14 @@ punt (int logout_p)
   if (connected)
     {
       shutdown (net, 2);
+      // cosmetics
+      if (clr_eol)
+	tputs (clr_eol, columns, putch);
+      ttyoflush ();
       printf ("Connection closed.\n");
+      // cosmetics
+      if (clr_eol)
+	tputs (clr_eol, columns, putch);
       ttyoflush ();
       close (net);
     }

--- a/supdup.c
+++ b/supdup.c
@@ -1517,9 +1517,12 @@ suprcv (void)
 //      if(c>=0&&c<128)
 //        printf("State: %d, Incoming: %d. Translation: %s\n", state, c, charmap[c].name);
       if (debug) {
-	if (c < 0200)
-	  fprintf(stderr,"State: %d, Incoming: %#o. Translation: %s\r\n", state, c, charmap[c].name);
-	else
+	if (c < 0200) {
+	  if (greeting_done)
+	    fprintf(stderr,"State: %d, Incoming: %#o. Translation: %s\r\n", state, c, charmap[c].name);
+	  else
+	    fprintf(stderr,"State: %d, Incoming: %#o.\r\n", state, c);
+	} else
 	  fprintf(stderr,"State: %d, Incoming: %#o (TD%s)\r\n", state, c,
 		  c == TDCRL ? "CRL" : c == TDNOP ? "NOP" : c == TDEOL ? "EOL" : c == TDCLR ? "CLR" : "xxx");
 	if (c == TDCLR) c = TDNOP;

--- a/supdup.c
+++ b/supdup.c
@@ -694,7 +694,7 @@ main (int argc, char **argv)
   exit (0);
 }
 
-static char inits[] =
+static signed char inits[] =
   {
     /* -wordcount,,0.  should always be -6 unless ispeed, ospeed and uname are there*/
     077,	077,	-6,	0,	0,	0,
@@ -806,6 +806,7 @@ sup_term (void)
       (insert_character || parm_ich))
     inits[14] |= 01;
 
+#if 0 // @@@@ fixme later
   if (ispeed != 0) {
     for (i = 0; i < 6; i++)
       inits[(7*6)+i] = (ispeed>>((5-i)*6)) & 077;
@@ -822,6 +823,7 @@ sup_term (void)
   }
   // note that we have 9 values being sent
   inits[2] = -9;
+#endif
 }
 
 #if !USE_TERMIOS

--- a/supdup.c
+++ b/supdup.c
@@ -1396,6 +1396,9 @@ suprcv (void)
   int c;
   static int state = SR_DATA;
   static int y;
+  // The text until the first TDNOP should be shown in ASCII, without translation.
+  // See RFC 734, bottom of page 3, or SUPIN2 in SYSNET;SUPDUP > (for ITS).
+  static int greeting_done = 0;
 
   while (scc > 0)
     {
@@ -1411,7 +1414,7 @@ suprcv (void)
               if (currcol < columns)
                 {
                   currcol++;
-                  if(unicode_translation) {
+                  if(unicode_translation && greeting_done) {
                     char *s = charmap[c].utf8;
                     while(*s) {
                       *ttyfrontp++ = *s++;
@@ -1485,6 +1488,7 @@ suprcv (void)
                 tputs (clr_eol, columns - currcol, putch);
               continue;
             case TDNOP:
+	      greeting_done = 1;
               continue;
             case TDORS:         /* ignore interrupts and */
 	      if (debug) fprintf(stderr,"TDORS at %d %d\n", currline, currcol);

--- a/supdup.c
+++ b/supdup.c
@@ -421,7 +421,7 @@ main (int argc, char **argv)
   if (sp == 0)
     {
       fprintf (stderr, "supdup: tcp/supdup: unknown service.\n");
-      sp->s_port = 79; // standard
+      sp->s_port = 95; // standard
     }
 
 #if !USE_TERMIOS


### PR DESCRIPTION
f the host parameter given can be on Chaosnet (based on DNS or that it's a valid 16-bit chaos address, **and** that cbridge allows a connection), connect using the stream interface of cbridge, else use Internet as usual.

Also send three extra Supdup variables (supported by ITS), and some minor things.