### PR TITLE
Makefile fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ supdup: supdup.o charmap.o
 supdupd: supdupd.o
 	$(CC) $(LDFLAGS) -o $@ $^
 
-install: supdup supdupd
+install: supdup
 	install -m 0755 supdup ${PREFIX}/bin
 	test -x supdupd && install -m 0755 supdupd ${PREFIX}/bin
 

--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,8 @@ supdupd: supdupd.o
 	$(CC) $(LDFLAGS) -o $@ $^
 
 install: supdup
-	install -m 0755 supdup ${PREFIX}/bin
-	test -x supdupd && install -m 0755 supdupd ${PREFIX}/bin
+	install -m 0755 supdup $(PREFIX)/bin
+	test -x supdupd && install -m 0755 supdupd $(PREFIX)/bin
 
 clean:
 	rm -f *.o

--- a/Makefile
+++ b/Makefile
@@ -5,13 +5,12 @@ PREFIX ?= /usr/local
 CC = cc
 CFLAGS = -g -Wall
 LDFLAGS = -g
-LIBS = -lncurses
 
 # The server isn't ready for prime time.
 all:	supdup
 
 supdup: supdup.o charmap.o
-	$(CC) $(LDFLAGS) -o $@ $^ $(LIBS)
+	$(CC) $(LDFLAGS) -o $@ $^ -lncurses
 
 supdupd: supdupd.o
 	$(CC) $(LDFLAGS) -o $@ $^

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,6 @@ CFLAGS = -g -Wall
 LDFLAGS = -g
 OBJS = supdup.o charmap.o
 LIBS = -lncurses
-SERVER = supdupd
 CC = cc
 
 # The server isn't ready for prime time.
@@ -15,12 +14,12 @@ all:	supdup
 supdup: $(OBJS)
 	$(CC) $(LDFLAGS) -o $@ $^ $(LIBS)
 
-$(SERVER): supdupd.o
+supdupd: supdupd.o
 	$(CC) $(LDFLAGS) -o $@ $^
 
-install: supdup $(SERVER)
+install: supdup supdupd
 	install -m 0755 supdup ${PREFIX}/bin
 	test -x supdupd && install -m 0755 supdupd ${PREFIX}/bin
 
 clean:
-	rm -f supdup $(SERVER) $(OBJS)
+	rm -f supdup supdupd $(OBJS)

--- a/Makefile
+++ b/Makefile
@@ -4,14 +4,13 @@ PREFIX ?= /usr/local
 
 CFLAGS = -g -Wall
 LDFLAGS = -g
-OBJS = supdup.o charmap.o
 LIBS = -lncurses
 CC = cc
 
 # The server isn't ready for prime time.
 all:	supdup
 
-supdup: $(OBJS)
+supdup: supdup.o charmap.o
 	$(CC) $(LDFLAGS) -o $@ $^ $(LIBS)
 
 supdupd: supdupd.o

--- a/Makefile
+++ b/Makefile
@@ -22,4 +22,5 @@ install: supdup supdupd
 	test -x supdupd && install -m 0755 supdupd ${PREFIX}/bin
 
 clean:
-	rm -f supdup supdupd $(OBJS)
+	rm -f *.o
+	rm -f supdup supdupd

--- a/Makefile
+++ b/Makefile
@@ -9,11 +9,13 @@ LDFLAGS = -g
 # The server isn't ready for prime time.
 all:	supdup
 
-supdup: supdup.o charmap.o
-	$(CC) $(LDFLAGS) -o $@ $^ -lncurses
+SUPDUP_OBJS = supdup.o charmap.o
+supdup: $(SUPDUP_OBJS)
+	$(CC) $(LDFLAGS) -o $@ $(SUPDUP_OBJS) -lncurses
 
-supdupd: supdupd.o
-	$(CC) $(LDFLAGS) -o $@ $^
+SUPDUPD_OBJS = supdupd.o
+supdupd: $(SUPDUPD_OBJS)
+	$(CC) $(LDFLAGS) -o $@ $(SUPDUPD_OBJS)
 
 install: supdup
 	install -m 0755 supdup $(PREFIX)/bin

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Makefile for the supdup server and user.
+# Makefile for the supdup server and client.
 
 PREFIX ?= /usr/local
 

--- a/Makefile
+++ b/Makefile
@@ -6,22 +6,21 @@ CFLAGS = -g -Wall
 LDFLAGS = -g
 OBJS = supdup.o charmap.o
 LIBS = -lncurses
-CLIENT = supdup
 SERVER = supdupd
 CC = cc
 
 # The server isn't ready for prime time.
-all:	$(CLIENT)
+all:	supdup
 
-$(CLIENT): $(OBJS)
+supdup: $(OBJS)
 	$(CC) $(LDFLAGS) -o $@ $^ $(LIBS)
 
 $(SERVER): supdupd.o
 	$(CC) $(LDFLAGS) -o $@ $^
 
-install: $(CLIENT) $(SERVER)
+install: supdup $(SERVER)
 	install -m 0755 supdup ${PREFIX}/bin
 	test -x supdupd && install -m 0755 supdupd ${PREFIX}/bin
 
 clean:
-	rm -f $(CLIENT) $(SERVER) $(OBJS)
+	rm -f supdup $(SERVER) $(OBJS)

--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,10 @@
 
 PREFIX ?= /usr/local
 
+CC = cc
 CFLAGS = -g -Wall
 LDFLAGS = -g
 LIBS = -lncurses
-CC = cc
 
 # The server isn't ready for prime time.
 all:	supdup


### PR DESCRIPTION
Cleans up the Makefile somewhat, makes it work on OpenBSD.

It also fixes one annoyance where there install target has a prerequisite on supdupd; supdupd isn't built by default but built when doing install.