### PR TITLE
Allow connections to the "local subnet" 376.

### DIFF
--- a/supdup.c
+++ b/supdup.c
@@ -362,7 +362,7 @@ get_chaos_host(char *name)
     return NULL;
 
   if ((sscanf(name, "%ho", &haddrs[0]) == 1) && 
-      (haddrs[0] > 0xff) && (haddrs[0] < 0xfe00) && ((haddrs[0] & 0xff) != 0)) {
+      (haddrs[0] > 0xff) && (haddrs[0] < 0xff00) && ((haddrs[0] & 0xff) != 0)) {
     // Use the address for a "name": it is precise, and it works with the cbridge parser
     return name;
   }


### PR DESCRIPTION
I tried to set up a local Chaos network much like described in http://chaosnet.net/local, but supdup wouldn't connect to my ITS host.  Checking the supdup code, I see `get_chaos_host` will not allow an octal address with the subnet part being 376.  This pull request changes that, and now the connection succeeds.  I'm not sure what the intent was in not allowing subnet 376, so I hope this can be explained and hashed out.