### PR TITLE
Don't clobber the hostname passed to Chaosnet NCP

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,9 +19,9 @@ endif
 # The server isn't ready for prime time.
 all:	supdup
 
-SUPDUP_OBJS = supdup.o charmap.o
+SUPDUP_OBJS = supdup.o charmap.o tcp.o chaos.o
 supdup: $(SUPDUP_OBJS)
-	$(CC) $(LDFLAGS) -o $@ $(SUPDUP_OBJS) -lncurses -lresolv
+	$(CC) $(LDFLAGS) -o $@ $(SUPDUP_OBJS) -lncurses
 
 SUPDUPD_OBJS = supdupd.o
 supdupd: $(SUPDUPD_OBJS)

--- a/chaos.c
+++ b/chaos.c
@@ -1,0 +1,130 @@
+/* Chaosnet specific code, pulled out from supdup.c. */
+
+#include "supdup.h"
+
+#if USE_CHAOS_STREAM_SOCKET
+
+#include <stdio.h>
+#include <netdb.h>
+#include <unistd.h>
+#include <string.h>
+#include <sys/un.h>
+
+// Where are the chaos sockets? Cf. https://github.com/bictorv/chaosnet-bridge
+#ifndef CHAOS_SOCKET_DIRECTORY
+#define CHAOS_SOCKET_DIRECTORY "/tmp"
+#endif
+// What DNS domain should be used to translate Chaos addresses to names?
+#ifndef CHAOS_ADDRESS_DOMAIN
+#define CHAOS_ADDRESS_DOMAIN "ch-addr.net"
+#endif
+// What DNS server should be used to fetch Chaos class data?
+#ifndef CHAOS_DNS_SERVER
+// #define CHAOS_DNS_SERVER "130.238.19.25"
+#define CHAOS_DNS_SERVER "dns.chaosnet.net"
+#endif
+
+static int
+connect_to_named_socket(int socktype, char *path)
+{
+  int sock, slen;
+  struct sockaddr_un server;
+  
+  if ((sock = socket(AF_UNIX, socktype, 0)) < 0) {
+    perror("socket(AF_UNIX)");
+    return -1;
+  }
+
+  server.sun_family = AF_UNIX;
+  sprintf(server.sun_path, "%s/%s", CHAOS_SOCKET_DIRECTORY, path);
+  slen = strlen(server.sun_path)+ 1 + sizeof(server.sun_family);
+
+  if (connect(sock, (struct sockaddr *)&server, slen) < 0) {
+    perror("connect(server)");
+    return 0;
+  }
+  return sock;
+}
+
+static ssize_t write_all(int fd, void *buf, size_t n)
+{
+  char *x = buf;
+  ssize_t m;
+  while (n > 0) {
+    m = write(fd, x, n);
+    if (m == 0)
+      break;
+    if (m < 0)
+      return m;
+    x += m;
+    n -= m;
+  }    
+  return x - (char *)buf;
+}
+
+static ssize_t read_all(int fd, void *buf, size_t n)
+{
+  char *x = buf;
+  ssize_t m;
+  while (n > 0) {
+    m = read(fd, x, n);
+    if (m == 0)
+      break;
+    if (m < 0)
+      return m;
+    x += m;
+    n -= m;
+  }    
+  return x - (char *)buf;
+}
+
+static int
+connection(int net, const char *host, const char *contact) 
+{
+  char buf[1000]; /*Bill Gates says this ought to be enough.*/
+  char *bp, cbuf[2];
+  size_t n;
+
+  n = snprintf(buf, sizeof buf, "RFC %s %s\r\n", host, contact);
+  if (write_all(net, buf, n) < n)
+    return -1;
+
+  bp = buf;
+  while (read_all(net, cbuf, 1) == 1) {
+    if ((cbuf[0] != '\r') && (cbuf[0] != '\n'))
+      *bp++ = cbuf[0];
+    else {
+      *bp = '\0';
+      break;
+    }
+  }
+  if (strncmp(buf,"OPN ", 4) == 0)
+    return 0;
+  else
+    return -1;
+}
+
+int
+chaos_connect(const char *hostname, const char *contact)
+{
+  int fd = connect_to_named_socket(SOCK_STREAM, "chaos_stream");
+  if (contact == NULL)
+    contact = "SUPDUP";
+  if (connection(fd, hostname, contact) < 0) {
+    close(fd);
+    return -1;
+  }
+  return fd;
+}
+
+#else /* !USE_CHAOS_STREAM_SOCKET */
+
+int
+chaos_connect(const char *hostname, const char *contact)
+{
+  (void)hostname;
+  (void)contact;
+  return -1;
+}
+
+#endif /* !USE_CHAOS_STREAM_SOCKET */

--- a/supdup.c
+++ b/supdup.c
@@ -74,9 +74,6 @@
 #include "supdup.h"
 #include "charmap.h"
 
-#define OUTSTRING_BUFSIZ 2048
-unsigned char *outstring;
-
 #define TBUFSIZ 1024
 unsigned char ttyobuf[TBUFSIZ];
 unsigned char *ttyfrontp = ttyobuf;
@@ -671,12 +668,6 @@ main (int argc, char **argv)
     {
       perror ("supdup: socket");
       exit(1);
-    }
-  outstring = (unsigned char *) malloc (OUTSTRING_BUFSIZ);
-  if (outstring == 0)
-    {
-      fprintf (stderr, "Memory exhausted.\n");
-      exit (1);
     }
   sup_term ();
   if (debug && setsockopt (net, SOL_SOCKET, SO_DEBUG, 0, 0) < 0)

--- a/supdup.h
+++ b/supdup.h
@@ -109,3 +109,9 @@ char ttyopt[6];
 #define TPPRN	(ttyopt[4] & 2)		/* Swap parens and brackets (ignored)*/
 short ttyrol;	/* How much the terminal scrolls by */
 
+#ifndef USE_CHAOS_STREAM_SOCKET
+#define USE_CHAOS_STREAM_SOCKET 1
+#endif
+
+extern int chaos_connect(const char *host, const char *contact);
+extern int tcp_connect(const char *host, const char *port);

--- a/tcp.c
+++ b/tcp.c
@@ -1,0 +1,82 @@
+/* TCP specific code, pulled out from supdup.c. */
+
+#include <stdio.h>
+#include <netdb.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include "supdup.h"
+
+#define STANDARD_PORT 95  /*Per gospel from St. Postel.*/
+
+static int
+get_port(struct sockaddr_in *tsin, const char *port)
+{
+  if (port == NULL) {
+    struct servent *sp = getservbyname ("supdup", "tcp");
+    if (sp == NULL)
+      tsin->sin_port = htons(STANDARD_PORT);
+    else
+      tsin->sin_port = sp->s_port;
+  } else {
+    tsin->sin_port = atoi (port);
+    if (tsin->sin_port <= 0) {
+      fprintf(stderr,"%s: bad port number.\n", port);
+      return -1;
+    }
+    tsin->sin_port = htons (tsin->sin_port);
+  }
+  return 0;
+}
+
+static int
+get_host (struct sockaddr_in *tsin, const char *name)
+{
+  struct hostent *host;
+  host = gethostbyname (name);
+  if (host)
+    {
+      tsin->sin_family = host->h_addrtype;
+#ifdef notdef
+      bcopy (host->h_addr_list[0], (caddr_t) &tsin->sin_addr, host->h_length);
+#else
+      bcopy (host->h_addr, (caddr_t) &tsin->sin_addr, host->h_length);
+#endif /* h_addr */
+      return 0;
+    }
+  else
+    {
+      tsin->sin_family = AF_INET;
+      tsin->sin_addr.s_addr = inet_addr (name);
+      if (tsin->sin_addr.s_addr == -1)
+        return -1;
+      else
+        return 0;
+    }
+}
+
+int
+tcp_connect(const char *host, const char *port)
+{
+  struct sockaddr_in tsin;
+  int fd;
+
+  if (get_port(&tsin, port) < 0 || get_host(&tsin, host) < 0)
+    return -1;
+
+  fd = socket (AF_INET, SOCK_STREAM, 0);
+  if (fd < 0) {
+    perror ("supdup: socket");
+    return -1;
+  }
+
+  if (connect (fd, (struct sockaddr *) &tsin, sizeof (tsin)) < 0) {
+    close(fd);
+    perror ("supdup: connect");
+    return -1;
+  }
+
+  return fd;
+}


### PR DESCRIPTION
As discussed in #31.  The seemingly small change &mdash; avoid appending ".Chaosnet.NET" to an unqualified Chaosnet hostname &mdash; had far reaching repercussions.  Due to how the code was previously structured, a small local change was not possible.

All the network-specific code has now been pulled out into two files tcp.c and chaos.c, which know how to take a hostname and port/contact and make a connection.  The Chaosnet host name resolution has been thrown out completely, leaving that to the NCP.

Three different use cases have been tested:
- Local Chaosnet octal node address: `supdup 3150` for TT ITS, and `supdup 177002` for the local subnet ITS.
- Global Chaosnet hostname: `supdup es.swenson.org`
- Internet hostname: `supdup sv.svensson.org`