### PR TITLE
Move definitions of ttyopt and ttyrol from supdup.h into supdupd.c.

### DIFF
--- a/chaos.c
+++ b/chaos.c
@@ -1,5 +1,7 @@
 /* Chaosnet specific code, pulled out from supdup.c. */
 
+#include "supdup.h"
+
 #if USE_CHAOS_STREAM_SOCKET
 
 #include <stdio.h>

--- a/supdup.h
+++ b/supdup.h
@@ -94,21 +94,6 @@
 
 #define TDUP	0237	/* Interpreted locally, not in supdup spec at all */
 
-/* These variables are set at initial connection time */
-char ttyopt[6];
-#define TOERS	(ttyopt[0] & 4)		/* Terminal can erase */
-#define TOMVB	(ttyopt[0] & 1)		/* can move backwards */
-#define TOOVR	(ttyopt[1] & 010)	/* Over printing */
-#define TOMVU	(ttyopt[1] & 4)		/* can move up */
-#define TOFCI	(ttyopt[2] & 010)	/* Terminal can transmit full 12-bit MIT ascii */
-#define TOLID	(ttyopt[2] & 2)		/* Line insert/delete */
-#define TOCID	(ttyopt[2] & 1)		/* Character insert/delete */
-#define TOSA1	(ttyopt[1] & 020)	/* send SAIL characters direct */
-#define TOMOR	(ttyopt[1] & 2)		/* Do more processing */
-#define TOROL	(ttyopt[1] & 1)		/* Do scrolling */
-#define TPPRN	(ttyopt[4] & 2)		/* Swap parens and brackets (ignored)*/
-short ttyrol;	/* How much the terminal scrolls by */
-
 #ifndef USE_CHAOS_STREAM_SOCKET
 #define USE_CHAOS_STREAM_SOCKET 1
 #endif

--- a/supdupd.c
+++ b/supdupd.c
@@ -66,6 +66,21 @@
 #define	SBANNER	"%s SUPDUP from %s"
 #endif
 
+/* These variables are set at initial connection time */
+char ttyopt[6];
+#define TOERS	(ttyopt[0] & 4)		/* Terminal can erase */
+#define TOMVB	(ttyopt[0] & 1)		/* can move backwards */
+#define TOOVR	(ttyopt[1] & 010)	/* Over printing */
+#define TOMVU	(ttyopt[1] & 4)		/* can move up */
+#define TOFCI	(ttyopt[2] & 010)	/* Terminal can transmit full 12-bit MIT ascii */
+#define TOLID	(ttyopt[2] & 2)		/* Line insert/delete */
+#define TOCID	(ttyopt[2] & 1)		/* Character insert/delete */
+#define TOSA1	(ttyopt[1] & 020)	/* send SAIL characters direct */
+#define TOMOR	(ttyopt[1] & 2)		/* Do more processing */
+#define TOROL	(ttyopt[1] & 1)		/* Do scrolling */
+#define TPPRN	(ttyopt[4] & 2)		/* Swap parens and brackets (ignored)*/
+short ttyrol;	/* How much the terminal scrolls by */
+
 /* * I/O data buffers, pointers, and counters. */
 unsigned char ptyibuf[BUFSIZ], *ptyip = ptyibuf;
 unsigned char ptyobuf[BUFSIZ], *pfrontp = ptyobuf, *pbackp = ptyobuf;

--- a/tcp.c
+++ b/tcp.c
@@ -7,6 +7,7 @@
 #include <unistd.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
+#include "supdup.h"
 
 #define STANDARD_PORT 95  /*Per gospel from St. Postel.*/
 


### PR DESCRIPTION
The latest commit - d3f5019 - tried to fix this problem:
```
cc -g -o supdup supdup.o charmap.o tcp.o chaos.o -lncurses
/usr/bin/ld: tcp.o:/home/runner/work/its/its/tools/supdup/supdup.h:98: multiple definition of `ttyopt'; supdup.o:/home/runner/work/its/its/tools/supdup/supdup.h:98: first defined here
/usr/bin/ld: tcp.o:/home/runner/work/its/its/tools/supdup/supdup.h:110: multiple definition of `ttyrol'; supdup.o:/home/runner/work/its/its/tools/supdup/supdup.h:110: first defined here
```

But the fix broke Chaosnet by not including supdup.h in chaos.c.

I believe the right fix is to move ttyopt and ttyrol into supdupd.c which is the only place they are used.