### PR TITLE
Portability improvements, cleanup, and bug fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 *~
 *.o
+*.ln
+compile_commands.json
 /supdup
+/supdupd

--- a/INFO
+++ b/INFO
@@ -26,7 +26,7 @@ reappears.  They also have a bug that if you type a meta character the
 character that gets sent is shifted and if you type meta shift character
 it sends a lowercase character.  There is nothing I can do about this.
 
-For some reason talk, amoung a few other things, core dumps when
+For some reason talk, among a few other things, core dumps when
 supduping in from a lisp machine (either a 3600 or a cadr).  I've seen
 the same bug a BBN bitgraph.  It seems to be a bug with programs which
 use curses and is evoked by large screen sizes.

--- a/Makefile
+++ b/Makefile
@@ -1,36 +1,97 @@
 # Makefile for the supdup server and client.
 
-PREFIX ?= /usr/local
+SHELL=/bin/sh
+PREFIX?=/usr/local
 
-OS_NAME = $(shell uname)
-ifeq ($(OS_NAME), Darwin)
-OS = OSX
+OS_NAME?=$(shell uname 2> /dev/null)
+CFLAGS+=$(shell pkg-config --cflags ncurses 2> /dev/null)
+NCURSES_LIBS?=$(shell pkg-config --libs ncurses 2> /dev/null || printf '%s' "-lncurses")
+
+# AIX (requires linking libcurses *after* libncurses!)
+ifeq ($(OS_NAME),AIX)
+ EXTRA_LDFLAGS=-lcurses
 endif
 
-CC = cc
-CFLAGS = -g -Wall
-LDFLAGS = -g
-
-# Mac OSX
-ifeq ($(OS), OSX)
-LDFLAGS = -L/opt/local/lib
+# Mac OS X
+ifeq ($(OS_NAME),Darwin)
+ ifneq (,$(wildcard /opt/local/include))
+  CFLAGS+=-I/opt/local/include
+ else
+  ifneq (,$(wildcard /usr/local/include))
+   CFLAGS+=-I/usr/local/include
+  endif
+ endif
+ ifneq (,$(wildcard /opt/local/lib))
+  LDFLAGS+=-L/opt/local/lib
+ else
+  ifneq (,$(wildcard /usr/local/lib))
+   LDFLAGS+=-L/usr/local/lib
+  endif
+ endif
 endif
 
-# The server isn't ready for prime time.
-all:	supdup
+# Solaris and illumos
+ifeq ($(OS_NAME),SunOS)
+ CFLAGS+=-I/usr/include/ncurses
+ EXTRA_LDFLAGS=-lnsl -lsocket
+endif
+
+# Haiku
+ifeq ($(OS_NAME),Haiku)
+ EXTRA_LDFLAGS=-lnetwork
+endif
+
+# NetBSD
+ifeq ($(OS_NAME),NetBSD)
+ CFLAGS+=-I/usr/pkg/include -I/usr/pkg/include/ncurses
+ LDFLAGS+=-L/usr/pkg/lib
+endif
+
+# The server (supdupd) and supdup-login aren't ready for prime time.
+.PHONY: all
+all: supdup
 
 SUPDUP_OBJS = supdup.o charmap.o tcp.o chaos.o
 supdup: $(SUPDUP_OBJS)
-	$(CC) $(LDFLAGS) -o $@ $(SUPDUP_OBJS) -lncurses
+	$(CC) $(LDFLAGS) -o $@ $(SUPDUP_OBJS) $(NCURSES_LIBS) $(EXTRA_LDFLAGS)
 
 SUPDUPD_OBJS = supdupd.o
 supdupd: $(SUPDUPD_OBJS)
 	$(CC) $(LDFLAGS) -o $@ $(SUPDUPD_OBJS)
 
+.PHONY: install
 install: supdup
 	install -m 0755 supdup $(PREFIX)/bin
 	test -x supdupd && install -m 0755 supdupd $(PREFIX)/bin
 
+.PHONY: clean
 clean:
-	rm -f *.o
-	rm -f supdup supdupd
+	$(RM) *.o
+	$(RM) supdup supdupd
+
+.PHONY: distclean
+distclean: clean
+	$(RM) *~ *.bak core *.core
+
+.PHONY: printvars printenv
+printvars printenv:
+	-@printf '%s: ' "FEATURES" 2> /dev/null
+	-@printf '%s ' "$(.FEATURES)" 2> /dev/null
+	-@printf '%s\n' "" 2> /dev/null
+	-@$(foreach V,$(sort $(.VARIABLES)), \
+	  $(if $(filter-out environment% default automatic,$(origin $V)), \
+	  $(if $(strip $($V)),$(info $V: [$($V)]),)))
+	-@true > /dev/null 2>&1
+
+.PHONY: print-%
+print-%:
+	-@$(info $*: [$($*)] ($(flavor $*). set by $(origin $*)))@true
+	-@true > /dev/null 2>&1
+
+# Dependencies
+chaos.o: chaos.c supdup.h
+charmap.o: charmap.c charmap.h
+supdup.o: supdup.c supdup.h charmap.h
+supdupd.o: supdupd.c supdup.h
+supdup-login.o: supdup-login.c
+tcp.o: tcp.c supdup.h

--- a/README.md
+++ b/README.md
@@ -1,1 +1,95 @@
-![](https://travis-ci.org/larsbrinkhoff/lbForth.svg?branch=master)
+# `supdup`
+
+## Overview
+
+* `supdup` is a client (and `supdupd` is a server) implementing the SUPDUP (*Sup*er *Dup*er TELNET) protocol, a highly efficient [TELNET](https://www.rfc-editor.org/rfc/rfc854.txt)-style remote display protocol, on UNIX-like systems.
+
+* It originated as a private protocol between the [Chaosnet](https://chaosnet.net/)-connected ITS systems at MIT to allow a user at any one of these systems to use one of the others as a display; later implementations were developed for [various platforms](https://gunkies.org/wiki/Chaosnet#Protocol_implementations).
+
+* The software creates connections over TCP/IP and Chaosnet (optionally using the [cbridge](https://github.com/bictorv/chaosnet-bridge) software).
+
+## Tested platforms
+
+* Tested operating systems: Oracle Solaris, OpenIndiana illumos, Linux/musl, Linux/glibc, IBM AIX, IBM OS/400 (PASE), Haiku, FreeBSD, OpenBSD, NetBSD, DragonFly BSD, Cygwin, and Apple macOS.
+
+## Tested compilers
+
+* Tested compilers: PCC, GCC, Clang, Xcode, IBM XL C, IBM Open XL C, Oracle Studio C, NVIDIA HPC SDK C, Portland Group C, and DMD ImportC.
+
+## Building the `supdup` client
+
+### Generic UNIX
+
+* Building on generic UNIX-like systems (**Linux**, **\*BSD**, **macOS**, **Haiku**, etc.):
+  * Install prerequisite packages:
+    * Required: `make` (GNU), `ncurses` (libraries and headers),
+    * Recommended: `pkg-config`
+  * Build: `gmake` (or sometimes just `make`)
+[]()
+
+[]()
+* The usual environment variables (*e.g.* `CC`, `CFLAGS`, `LDFLAGS`, etc.) are respected, for example:
+  * `env CC="gcc" CFLAGS="-Wall" LDFLAGS="-L/usr/local" gmake`
+
+### IBM AIX
+
+* Building on IBM AIX 7:
+  * Install prerequisite packages:
+    * `dnf install make ncurses-devel pkg-config`
+  * Build with IBM XL C V16:
+    * `env CC="xlc" CFLAGS="-q64" LDFLAGS="-q64" gmake`
+  * Build with IBM Open XL C V17:
+    * `env CC="ibm-clang" CFLAGS="-m64" LDFLAGS="-m64" gmake`
+  * Build with GNU GCC:
+    * `env CC="gcc" CFLAGS="-maix64" LDFLAGS="-maix64 -Wl,-b64" gmake`
+  * Build with Clang:
+    * `env CC="clang" CFLAGS="-m64" LDFLAGS="-m64" gmake`
+
+### IBM i (OS/400)
+
+* Building on PASE for IBM i (OS/400):
+  * Install prerequisite packages:
+    * `yum install gcc10 make-gnu ncurses-devel pkg-config`
+  * Build with GNU GCC:
+    * `env CC="gcc-10" CFLAGS="-maix64" LDFLAGS="-maix64 -Wl,-b64" gmake`
+
+### DMD ImportC
+
+* Building with DMD ImportC:
+  * `dmd -betterC -c -of=supdup.o chaos.c charmap.c supdup.c tcp.c $(pkg-config --cflags-only-I ncurses)`
+  * `cc -o supdup supdup.o $(pkg-config --libs ncurses)`
+
+## Building the `supdup` server
+
+* An *experimental* server, `supdupd`, is included.
+* The server component is *antiquated*, *incomplete*, and *will not* build on all platforms.
+[]()
+
+[]()
+* To build the server on generic UNIX-like systems:
+  * Install prerequisite packages: `make` (GNU)
+  * Build: `gmake` (or sometimes just `make`)
+
+## Bug Reporting
+
+* To report a problem with `supdup`, use GitHub Issues:
+  * https://github.com/PDP-10/supdup/issues/new/choose
+
+## External links
+
+### SUPDUP
+
+* [RFC 734: SUPDUP Protocol](https://www.rfc-editor.org/rfc/rfc734.txt)
+* [RFC 736: TELNET SUPDUP Option](https://www.rfc-editor.org/rfc/rfc736.txt)
+* [RFC 746: The SUPDUP Graphics Extension](https://www.rfc-editor.org/rfc/rfc746.txt)
+* [RFC 747: Recent Extensions to the SUPDUP Protocol](https://www.rfc-editor.org/rfc/rfc747.txt)
+* [RFC 749: TELNET SUPDUP-OUTPUT Option](https://www.rfc-editor.org/rfc/rfc749.txt)
+* [AI Memo 643: A Local Front End for Remote Editing](http://www.bitsavers.org/pdf/mit/ai/aim/AIM-643.pdf)
+* [AI Memo 644: The SUPDUP Protocol](http://www.bitsavers.org/pdf/mit/ai/aim/AIM-644.pdf)
+* [PuTTY: SUPDUP Backend](https://git.tartarus.org/?p=simon/putty.git;a=blob;f=otherbackends/supdup.c;h=6f574c9fb9c34b1307b67326038aa713c2b1d07a;hb=HEAD)
+
+### Chaosnet
+
+* [AI Memo 628: Chaosnet](http://bitsavers.org/pdf/mit/ai/AIM-628_chaosnet.pdf)
+* [Chaosnet Bridge](https://github.com/bictorv/chaosnet-bridge)
+* [Chaosnet Wiki](https://chaosnet.net/)

--- a/chaos.c
+++ b/chaos.c
@@ -9,7 +9,8 @@
 #include <unistd.h>
 #include <string.h>
 #include <sys/un.h>
-#include <sys/errno.h>
+#include <errno.h>
+#include <sys/socket.h>
 
 // Where are the chaos sockets? Cf. https://github.com/bictorv/chaosnet-bridge
 #ifndef CHAOS_SOCKET_DIRECTORY
@@ -41,7 +42,7 @@ connect_to_named_socket(int socktype, char *path)
   slen = strlen(server.sun_path)+ 1 + sizeof(server.sun_family);
 
   if (connect(sock, (struct sockaddr *)&server, slen) < 0) {
-    if (errno != ECONNREFUSED)
+    if (errno != ENOENT)
       // Fail silently if Chaosnet bridge is not there
       perror("connect(server)");
     return -1;
@@ -114,7 +115,8 @@ chaos_connect(const char *hostname, const char *contact)
   if (contact == NULL)
     contact = "SUPDUP";
   if (connection(fd, hostname, contact) < 0) {
-    close(fd);
+    if (fd >= 0)
+      close(fd);
     return -1;
   }
   return fd;

--- a/supdup-login.c
+++ b/supdup-login.c
@@ -658,7 +658,7 @@ doremoteterm(term, tp)
 	tp->sg_flags = ECHO|CRMOD|ANYP|XTABS;
 }
 
-#ifdef 0
+#if 0
 /* Use syslog instead */
 logerr(fmt, a1, a2, a3)
 	char *fmt, *a1, *a2, *a3;

--- a/supdup.h
+++ b/supdup.h
@@ -42,7 +42,7 @@
 #define ITP_MTA		00400	/* META key depressed */
 #define ITP_TOP		04000	/* TOP key depressed */
 #define CTL_PREFIX	0237	/* c-m-_ is control prefix */
-#define ITP_CHAR(char1,char2) (((char1 & 037) << 7) + char2)
+#define ITP_CHAR(char1,char2) ((((char1) & 037) << 7) + (char2))
 #define ITP_ESCAPE	034	/* ITS ITP codes follow */
 
 #define ITP_CURSORPOS 020	/* user sends vpos/hpos */


### PR DESCRIPTION
* Portability improvements, cleanup, and bug fixes:
  * Add or fix support for building on Solaris, illumos, Linux/musl, NetBSD, OpenBSD, IBM AIX, IBM OS/400 (PASE), Cygwin, and Haiku, which weren't previously cleanly building.
  * Use `pkg-config` when available to determine CFLAGS and libraries.
  * Initialize some variables in `supdupd`.
  * Fix off-by-one error in `supdup`.
  * Suppress spurious error when Chaosnet bridge socket is missing.
  * Create `README.md`.
  * Cleanup Makefile.
  * Properly detect bad ports (negative or >65535).
  * Fix non-ANSI function declarations.
  * Add `*.ln` (*Lint*) files, `supdupd`, and `compile_commands.json` to `.gitignore`.
  * Create `.gitattributes`.
  * Ensure file handle is valid (non-negative) before closing.
  * Correct various spelling errors.
[]()

[]()
  * Tested build under Oracle Solaris, OpenIndiana illumos, Linux/musl, Linux/glibc, IBM AIX, IBM OS/400 (PASE), Haiku, FreeBSD, OpenBSD, NetBSD, DragonFly BSD, Cygwin, and Apple macOS.

  * Compilation tested and working with PCC, GCC, Clang, Xcode, IBM XL C, IBM Open XL C, Oracle Studio C, NVIDIA HPC SDK C, Portland Group C, and DMD ImportC.

  * Passes Cppcheck and Clang Analyzer.
[]()

[]()
  * Resolves GitHub Issues:
    * Closes #25 
    * Closes #35
    * Closes #38

Signed-off-by: Jeffrey H. Johnson \<trnsz@pobox.com\>